### PR TITLE
Corrige rotas e organizacao de estaticos para producao Fixes fflch/analytics#11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,9 @@ apps/static/assets/node_modules
 apps/static/assets/yarn.lock
 apps/static/assets/.temp
 
+# collectstatic (Django Production)
 
+static/
 
 .virtualenv
 

--- a/apps/home/urls.py
+++ b/apps/home/urls.py
@@ -8,9 +8,6 @@ from django.views.static import serve
 from apps.home import views
 
 urlpatterns = [
-    url(r'^static/(?P<path>.*)$', serve,{'document_root': settings.STATIC_ROOT}), 
-
-    # The home page
     path('', views.IndexView.as_view(), name='home'),
 
     path('sobre-nos', views.SobrenosView.as_view(), name='sobre-nos'),

--- a/apps/templates/includes/header.html
+++ b/apps/templates/includes/header.html
@@ -1,3 +1,4 @@
+{% load static %}
 <div class="header bg-primary pb-6">
   <div class="container-fluid">
     {% if landingpage %}
@@ -11,7 +12,7 @@
             <!-- Celulas -->
 
               <a class="d-flex div-img-land" href="/">
-                <img src="/static/assets/img/brand/fundoazul.png" class="img-land">
+                <img src="{% static 'assets/img/brand/fundoazul.png' %}" class="img-land">
 
                 <div class="d-flex flex-column div-text-land">
                   <p class="p-text-logo">
@@ -27,7 +28,7 @@
         </div>
         <div>
           <a href="https://www5.usp.br/" target="_blank">
-            <img src="/static/assets/img/brand/usplogo.png" class="img-logo-usp">
+            <img src="{% static 'assets/img/brand/usplogo.png' %}" class="img-logo-usp">
           </a>
         </div>
       </div>

--- a/apps/templates/includes/navigation-fullscreen.html
+++ b/apps/templates/includes/navigation-fullscreen.html
@@ -1,7 +1,8 @@
+{% load static %}
 <nav id="navbar-main" class="navbar navbar-horizontal navbar-transparent navbar-main navbar-expand-lg navbar-light">
   <div class="container">
     <a class="navbar-brand" href="/">
-      <img src="/static/assets/img/brand/logo.png" alt="Argon Design - Template Starter Logo.">
+      <img src="{% static 'assets/img/brand/logo.png' %}" alt="Argon Design - Template Starter Logo.">
     </a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-collapse" aria-controls="navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
@@ -11,7 +12,7 @@
         <div class="row">
           <div class="col-6 collapse-brand">
             <a href="/">
-              <img src="/static/assets/img/brand/logo.png">
+              <img src="{% static 'assets/img/brand/logo.png' %}">
             </a>
           </div>
           <div class="col-6 collapse-close">

--- a/apps/templates/includes/scripts.html
+++ b/apps/templates/includes/scripts.html
@@ -1,8 +1,8 @@
-
-  <script src="/static/assets/vendor/jquery/dist/jquery.min.js"></script>
-  <script src="/static/assets/vendor/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/static/assets/vendor/jquery.scrollbar/jquery.scrollbar.min.js"></script>
-  <script src="/static/assets/vendor/jquery-scroll-lock/dist/jquery-scrollLock.min.js"></script>
-  <script src="/static/assets/js/datatables.min.js"></script>
+{% load static %}
+  <script src="{% static 'assets/vendor/jquery/dist/jquery.min.js' %}"></script>
+  <script src="{% static 'assets/vendor/bootstrap/dist/js/bootstrap.bundle.min.js' %}"></script>
+  <script src="{% static 'assets/vendor/jquery.scrollbar/jquery.scrollbar.min.js' %}"></script>
+  <script src="{% static 'assets/vendor/jquery-scroll-lock/dist/jquery-scrollLock.min.js' %}"></script>
+  <script src="{% static 'assets/js/datatables.min.js' %}"></script>
 
   

--- a/apps/templates/includes/sidenav.html
+++ b/apps/templates/includes/sidenav.html
@@ -1,3 +1,4 @@
+{% load static %}
 <nav class="sidenav navbar navbar-vertical  fixed-left  navbar-expand-xs navbar-light bg-white" id="sidenav-main">
   <div class="scrollbar-inner">
     <!-- Brand -->

--- a/apps/templates/layouts/base-fullscreen.html
+++ b/apps/templates/layouts/base-fullscreen.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 
@@ -10,13 +11,13 @@
     {{ name_app }}
   </title>
 
-  <link rel="icon" href="/static/assets/img/{{ icon }}" type="image/png">
+  <link rel="icon" href="{% static 'assets/img/icons/fflch_simbolo.jpg' %}" type="image/png">
   <!-- Fonts -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700">
   <!-- Icons -->
-  <link rel="stylesheet" href="/static/assets/vendor/@fortawesome/fontawesome-free/css/all.min.css" type="text/css">
+  <link rel="stylesheet" href="{% static 'assets/vendor/@fortawesome/fontawesome-free/css/all.min.css' %}" type="text/css">
   <!-- Argon CSS -->
-  <link rel="stylesheet" href="/static/assets/css/argon.css?v=1.2.0" type="text/css">
+    <link rel="stylesheet" href="{% static 'assets/css/argon.css' %}" type="text/css">
 
   <!-- Specific CSS goes HERE -->
   {% block stylesheets %}{% endblock stylesheets %}
@@ -58,7 +59,7 @@
   <!-- Specific JS goes HERE --> 
   {% block javascripts %}{% endblock javascripts %}
   
-  <script src="/static/assets/js/argon.js?v=1.2.0"></script>
+  <script src="{% static 'assets/js/argon.js' %}"></script>
 
 </body>
 

--- a/apps/templates/layouts/base.html
+++ b/apps/templates/layouts/base.html
@@ -12,20 +12,20 @@
   </title>
 
   <!-- Favicon - loaded as static -->
-  <link rel="icon" href="/static/assets/img/{{ icon }}" type="image/png">
+  <link rel="icon" href="{% static 'assets/img/icons/fflch_simbolo.jpg' %}" type="image/png">
   <!-- Fonts -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700">
   <!-- Icons -->
  
-  <link rel="stylesheet" href="/static/assets/vendor/@fortawesome/fontawesome-free/css/all.min.css" type="text/css">
+  <link rel="stylesheet" href="{% static 'assets/vendor/@fortawesome/fontawesome-free/css/all.min.css' %}" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jpswalsh/academicons@1/css/academicons.min.css">
   <!-- Page plugins -->
   <!-- Argon CSS -->
-  <link rel="stylesheet" href="/static/assets/css/argon.css" type="text/css">
+  <link rel="stylesheet" href="{% static 'assets/css/argon.css' %}" type="text/css">
   <!-- Specific CSS goes HERE -->
-  <link rel="stylesheet" href="/static/assets/css/styles.css" type="text/css">
+  <link rel="stylesheet" href="{% static 'assets/css/styles.css' %}" type="text/css">
   <!-- Jquery DataTables -->
-  <link rel="stylesheet" href="/static/assets/css/datatables.min.css">
+  <link rel="stylesheet" href="{% static 'assets/css/datatables.min.css' %}">
 
   {% block stylesheets %}{% endblock stylesheets %}
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -118,11 +118,10 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-if DEBUG:
-    STATICFILES_DIRS = (os.path.join(CORE_DIR, 'apps/static'),)
-else:
-    STATIC_ROOT = os.path.join(CORE_DIR, 'apps/static')
+STATICFILES_DIRS = (os.path.join(CORE_DIR, 'apps/static'),)
 
+if not DEBUG:
+    STATIC_ROOT = os.path.join(CORE_DIR, 'static')
 
 
 INTERNAL_IPS = [

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,15 +1,23 @@
-# -*- encoding: utf-8 -*-
-"""
-Copyright (c) 2019 - present AppSeed.us
-"""
-
 from django.contrib import admin
-from django.urls import path, include  # add this
+from django.urls import path, include, re_path
+from django.views.static import serve 
+from django.conf import settings
+from django.conf.urls.static import static 
 
 urlpatterns = [
     path('admin/', admin.site.urls),          # Django admin route
     path("", include("apps.authentication.urls")), # Auth routes - login / register
     path("", include("apps.home.urls")),             # UI Kits Html files
     # path("api/", include('apps.api.urls')),
-    path('__debug__/', include('debug_toolbar.urls')),
 ]
+
+if settings.DEBUG:
+    urlpatterns += [
+        path('__debug__/', include('debug_toolbar.urls')),
+    ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+else:
+    urlpatterns += [
+        re_path(r'static/(?P<path>.*)$', serve, {
+            'document_root': settings.STATIC_ROOT
+        })
+    ]


### PR DESCRIPTION
Corrige organização dos estaticos em desenvolvimento e em produção.

Antes todos os estaticos eram servidos de 'apps/static' em dev e em prod.

Agora os estaticos em dev ficam em 'apps/static' e os de prod sao gerados a partir do comando:

       python3 manage.py collectstatic

Os arquivos são gerados no diretório raiz.

Para eventualmente adicionar outros estáticos de outros apps na "compilacao" de estaticos basta adicionar a rotas dos mesmos à constante "STATICFILES_DIRS" no arquivo settings.py

Obs: Se rodar o servidor de desenvolvimento em DEBUG=False, também necessário rodar o collectstatic.

