### PR TITLE
Corrige falta do parametro sigla em populadb.py

### DIFF
--- a/populadb.py
+++ b/populadb.py
@@ -60,6 +60,7 @@ class PopulaDB():
             api_programas_docentes_limpo = departamento.pega_api_programas_docentes_limpo()
 
             departamento.atualiza_ou_cria_departamento(
+                                                    sigla,
                                                     api_docentes,
                                                     api_programas, 
                                                     api_pesquisa_vazio, 

--- a/services/populadb/Departamentos.py
+++ b/services/populadb/Departamentos.py
@@ -131,11 +131,12 @@ class ApiDepartamento:
 
         return api_programas_docentes_limpo
 
-    def atualiza_ou_cria_departamento(self, api_docentes, api_programas, api_pesquisa_vazio, api_pesquisa_parametros,api_defesas,api_programas_docentes,api_programas_docentes_limpo):
+    def atualiza_ou_cria_departamento(self, sigla, api_docentes, api_programas, api_pesquisa_vazio, api_pesquisa_parametros,api_defesas,api_programas_docentes,api_programas_docentes_limpo):
         departamento = Departamento.objects.filter(sigla=self.sigla)
 
         if departamento.exists():
             departamento.update(
+                sigla=sigla,
                 api_docentes=api_docentes,
                 api_programas=api_programas, 
                 api_pesquisa=api_pesquisa_vazio, 
@@ -147,6 +148,7 @@ class ApiDepartamento:
             print("Dados atualizados com sucesso")
         else:
             departamento = Departamento(
+                sigla=sigla,
                 api_docentes=api_docentes,
                 api_programas=api_programas, 
                 api_pesquisa=api_pesquisa_vazio, 


### PR DESCRIPTION
### Fix:

Antes o script funcionava somente para quem ja havia populado o banco de dados anteriormente com a versão pré-refatoração.

A falta do parametro faz com que na primeira vez que o script for rodado ele deixa a coluna 'sigla' em branco.

